### PR TITLE
Added/Updated files to save iterations

### DIFF
--- a/plugins/Full_CI_ZMQ/EZFIO.cfg
+++ b/plugins/Full_CI_ZMQ/EZFIO.cfg
@@ -8,4 +8,31 @@ type: double precision
 doc: Calculated FCI energy + PT2
 interface: ezfio
 
+[iterative]
+type:logical
+doc: Save the data at each iteration:
+interface: ezfio,ocaml
+default:.False.
 
+[n_iter]
+interface: ezfio
+doc: number of iterations
+type:integer
+
+[n_det_iter]
+interface: ezfio
+doc: number of determinants at iteration
+type: integer
+size: (full_ci_zmq.n_iter)
+ 
+[energy_iter]
+interface: ezfio
+doc: The energy without a pt2 correction for n_det
+type: double precision 
+size: (full_ci_zmq.n_iter)
+
+[energyBefore_pt2_iter]
+interface: ezfio
+doc: The energy with pt2 correction for n_det
+type: double precision 
+size: (full_ci_zmq.n_iter)

--- a/plugins/Full_CI_ZMQ/fci_iterations.irp.f
+++ b/plugins/Full_CI_ZMQ/fci_iterations.irp.f
@@ -1,0 +1,73 @@
+subroutine fci_iterations(n_determinants,energy,pt2)
+  implicit none
+  BEGIN_DOC
+! Output the number of determinants, energy, and pt2 correction at each iteration 
+  END_DOC
+  integer            		 :: n_determinants
+  double precision               :: energy, pt2,E_before
+  integer                        :: N_iterations
+  integer, allocatable           :: n_determinants_list(:)
+  double precision, allocatable  :: energy_list(:)
+  double precision, allocatable  :: energy_pt2_list(:)
+  logical			 :: saveIterations, hasIter
+
+
+
+  !!! CHECK TO ENSURE THAT WE SHOULD SAVE ITERATIONS (DEFAULT IS FALSE)
+  call ezfio_get_full_ci_zmq_iterative(saveIterations)
+  if (saveIterations) then
+
+
+     !!! If THE ITERATION IS PAST 1
+     !!! GET THE ITERATION NUMBER
+     !!! MAKE SURE THE CALCULATION IS ALSO NOT STARTING FROM SCRATCH
+     call ezfio_has_full_ci_zmq_n_iter(hasIter)
+     if((hasIter).AND.(n_determinants>1)) then
+         call ezfio_get_full_ci_zmq_n_iter(N_iterations)
+     else 
+         N_iterations = 0
+         E_before =0
+     endif
+
+    !! NOW ALLOCATE THE ARRAY FOR ENTIRE SIZE NEEDED
+    !! BUT FIRST CHECK TO ENSURE IT IS NOT STARTING FROM SCRATCH BY CHECKING IF THE NUM DETERMINANTS HAS INCREASED
+    allocate(n_determinants_list(N_iterations+1))
+    allocate(energy_list(N_iterations+1))
+    allocate(energy_pt2_list(N_iterations+1))
+
+
+
+     !!! PULL PREVIOUSLY WRITTEN DATA
+     !!! UNLESS ITS A NEW CALCULATION
+     if((hasIter).AND.(n_determinants>1)) then
+        call ezfio_get_full_ci_zmq_n_det_iter(n_determinants_list(1:N_iterations))
+        call ezfio_get_full_ci_zmq_energy_iter(energy_list(1:N_iterations))
+        E_before = energy_list(N_iterations)
+        call ezfio_get_full_ci_zmq_energyBefore_pt2_iter(energy_pt2_list(1:N_iterations))
+    endif
+
+
+    !! NOW INCREMENT TO THE CURRENT ITERATION
+    N_iterations = N_iterations+1
+
+  
+    !! ADD THE DATA FROM LATEST ITERATION 
+    n_determinants_list(N_iterations) = n_determinants
+    energy_list(N_iterations) = energy
+    energy_pt2_list(N_iterations) = E_before +pt2 
+
+    ! RESET THE ITERATION NUMBER 
+    call ezfio_set_full_ci_zmq_n_iter(N_iterations)
+ 
+    !!!! NOW RESET THE EZFIO VALUES
+    !!!! TO INCLUDE THE LATEST DATA
+    call ezfio_set_full_ci_zmq_n_det_iter(n_determinants_list)
+    call ezfio_set_full_ci_zmq_energy_iter(energy_list)
+    call ezfio_set_full_ci_zmq_energyBefore_pt2_iter(energy_pt2_list)
+
+    deallocate(n_determinants_list)
+    deallocate(energy_list)
+    deallocate(energy_pt2_list)
+
+  endif
+ end subroutine 

--- a/plugins/Full_CI_ZMQ/fci_zmq.irp.f
+++ b/plugins/Full_CI_ZMQ/fci_zmq.irp.f
@@ -25,6 +25,8 @@ program fci_zmq
     hf_energy_ref = ref_bitmask_energy
   endif
 
+  !!!!! THIS CALL IS NOT AUTOMATIC
+  call fci_iterations(N_det,CI_energy(1),pt2(1))
   if (N_det > N_det_max) then
     psi_det = psi_det_sorted
     psi_coef = psi_coef_sorted
@@ -41,6 +43,8 @@ program fci_zmq
       print *,  'E+PT2    = ', CI_energy(k) + pt2(k)
       print *,  '-----'
     enddo
+    !!!!! THIS CALL IS NOT AUTOMATIC
+    call fci_iterations(N_det,CI_energy(1),pt2(1))
   endif
   double precision               :: E_CI_before(N_states)
   
@@ -108,6 +112,8 @@ program fci_zmq
       call diagonalize_CI
       call save_wavefunction
       call ezfio_set_full_ci_zmq_energy(CI_energy(1))
+      !!!!! THIS CALL IS NOT AUTOMATIC
+      call fci_iterations(N_det,CI_energy(1),pt2(1))
     enddo
   endif
 
@@ -116,6 +122,8 @@ program fci_zmq
       call diagonalize_CI
       call save_wavefunction
       call ezfio_set_full_ci_zmq_energy(CI_energy(1))
+      !!!!! THIS CALL IS NOT AUTOMATIC
+      call fci_iterations(N_det,CI_energy(1),pt2(1))
   endif
 
   if(do_pt2_end)then
@@ -149,6 +157,8 @@ program fci_zmq
     enddo
     call ezfio_set_full_ci_zmq_energy(E_CI_before(1))
     call ezfio_set_full_ci_zmq_energy_pt2(E_CI_before(1)+pt2(1))
+    !!!!! THIS CALL IS NOT AUTOMATIC
+    call fci_iterations(N_det,CI_energy(1),pt2(1))
   endif
 
 end


### PR DESCRIPTION
Modified EZFIO.cfg to include iteratively saved data if the keyword of "full_ci_zmq/iterative" is set to true in the ezfio. The default is false. 
Will save the number of total iterations in full_ci_zmq/n_iter
Saves the number of determinants in full_ci_zmq/n_det_iter
Saves the energy in full_ci_zmq/energy_iter.
Saves the energy_pt2  in full_ci_zmq/energybefore_pt2_iter
These results are the same as the output of the program at every iteration.

Modified fci_zmq.irp.f to include calls to fci_iterations.irp.f at each iteration (starting at N_det==1 and including the final call to do the final pt2 correction)

Created fci_iterations as a subroutine to save the number of determinants, energy, and energy+pt2 for every iteration and saves the results in the full_ci_zmq output directory.